### PR TITLE
Fix Xcode 13 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 - Update `ThirdPartyMailClient.composeURL(...)` with default parameters values
 - Rename `ThirdPartyMailClient` `clients()` to `clients`
 - Update `ThirdPartyMailer` functions with completion handler instead of boolean return value
-- Rename `ThirdPartyMailer` `application(_, isMailClientAvailable:)` to `isMailClientAvailable(_, with:)`, with default parameters values
-- Rename `ThirdPartyMailer` `application(_, openMailClient:, completionHandler:)` to `open(_, with:, completionHandler:)`, with default parameters values
-- Rename `ThirdPartyMailer` `application(_, openMailClient:, recipient:, subject:, body:, completionHandler:)` to `openCompose(_, recipient:, subject:, body:, cc:, bcc:, with:, completionHandler:)`, with default parameters values
+- Rename `ThirdPartyMailer` `application(_, isMailClientAvailable:)` to `isMailClientAvailable(_)`, with default parameters values
+- Rename `ThirdPartyMailer` `application(_, openMailClient:, completionHandler:)` to `open(_, completionHandler:)`, with default parameters values
+- Rename `ThirdPartyMailer` `application(_, openMailClient:, recipient:, subject:, body:, completionHandler:)` to `openCompose(_, recipient:, subject:, body:, cc:, bcc:, completionHandler:)`, with default parameters values
 - Require iOS 10
 
 

--- a/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
+++ b/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
@@ -24,6 +24,7 @@
 import UIKit
 
 /// Tests third party mail clients availability, and opens third party mail clients in compose mode.
+@available(iOSApplicationExtension, unavailable)
 open class ThirdPartyMailer {
 
     /// Tests the availability of a third-party mail client.

--- a/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
+++ b/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
@@ -69,6 +69,7 @@ open class ThirdPartyMailer {
 }
 
 /// Extension with URL-specific methods for `UIApplication`, or any other object responsible for handling URLs.
+@available(iOSApplicationExtension, unavailable)
 public protocol UIApplicationOpenURLProtocol {
 
     /// Returns a Boolean value indicating whether or not the URL’s scheme can be handled by some app installed on the device.

--- a/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
+++ b/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
@@ -30,25 +30,25 @@ open class ThirdPartyMailer {
     /// Tests the availability of a third-party mail client.
     /// - Parameters:
     ///   - client: The third-party client to test.
-    ///   - application: The main application (optional, default value is `UIApplication.shared`).
     /// - Returns: `true` if the application can open the client; otherwise, `false`.
-    open class func isMailClientAvailable(_ client: ThirdPartyMailClient, with application: UIApplicationOpenURLProtocol = UIApplication.shared) -> Bool {
+    open class func isMailClientAvailable(_ client: ThirdPartyMailClient) -> Bool {
         var components = URLComponents()
         components.scheme = client.URLScheme
 
         guard let URL = components.url
             else { return false }
 
+        let application = UIApplication.shared
         return application.canOpenURL(URL)
     }
 
     /// Opens a third-party mail client.
     /// - Parameters:
     ///   - client: The third-party client to open.
-    ///   - application: The main application (optional, default value is `UIApplication.shared`).
     ///   - completion: The block to execute with the results (optional, default value is `nil`).
-    open class func open(_ client: ThirdPartyMailClient, with application: UIApplicationOpenURLProtocol = UIApplication.shared, completionHandler completion: ((Bool) -> Void)? = nil) {
+    open class func open(_ client: ThirdPartyMailClient, completionHandler completion: ((Bool) -> Void)? = nil) {
         let url = client.openURL()
+        let application = UIApplication.shared
         application.open(url, options: [:], completionHandler: completion)
     }
 
@@ -60,31 +60,10 @@ open class ThirdPartyMailer {
     ///   - body: The email body (optional, default value is `nil`).
     ///   - cc: The email address of the recipient carbon copy (optional, default value is `nil`).
     ///   - bcc: The email address of the recipient blind carbon copy (optional, default value is `nil`).
-    ///   - application: The main application (optional, default value is `UIApplication.shared`).
     ///   - completion: The block to execute with the results (optional, default value is `nil`).
-    open class func openCompose(_ client: ThirdPartyMailClient, recipient: String? = nil, subject: String? = nil, body: String? = nil, cc: String? = nil, bcc: String? = nil, with application: UIApplicationOpenURLProtocol = UIApplication.shared, completionHandler completion: ((Bool) -> Void)? = nil) {
+    open class func openCompose(_ client: ThirdPartyMailClient, recipient: String? = nil, subject: String? = nil, body: String? = nil, cc: String? = nil, bcc: String? = nil, with application: UIApplication = .shared, completionHandler completion: ((Bool) -> Void)? = nil) {
         let url = client.composeURL(to: recipient, subject: subject, body: body, cc: cc, bcc: bcc)
+        let application = UIApplication.shared
         application.open(url, options: [:], completionHandler: completion)
     }
 }
-
-/// Extension with URL-specific methods for `UIApplication`, or any other object responsible for handling URLs.
-@available(iOSApplicationExtension, unavailable)
-public protocol UIApplicationOpenURLProtocol {
-
-    /// Returns a Boolean value indicating whether or not the URL’s scheme can be handled by some app installed on the device.
-    /// - Parameter url: A URL (Universal Resource Locator). At runtime, the system tests the URL’s scheme to determine if there is an installed app that is registered to handle the scheme. More than one app can be registered to handle a scheme.
-    /// - Returns: `NO` if there is no app installed on the device that is registered to handle the URL’s scheme, or if you have not declared the URL’s scheme in your `Info.plist` file; otherwise, `YES`.
-    func canOpenURL(_ url: URL) -> Bool
-
-    /// Attempts to open the resource at the specified URL.
-    /// - Parameters:
-    ///   - url: The URL to open.
-    ///   - options: A dictionary of options to use when opening the URL
-    ///   - completion: The block to execute with the results.
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?)
-}
-
-/// Extend `UIApplication` to conform to the `UIApplicationOpenURLProtocol`.
-@available(iOSApplicationExtension, unavailable)
-extension UIApplication: UIApplicationOpenURLProtocol {}

--- a/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
+++ b/Sources/ThirdPartyMailer/ThirdPartyMailer.swift
@@ -86,4 +86,5 @@ public protocol UIApplicationOpenURLProtocol {
 }
 
 /// Extend `UIApplication` to conform to the `UIApplicationOpenURLProtocol`.
+@available(iOSApplicationExtension, unavailable)
 extension UIApplication: UIApplicationOpenURLProtocol {}

--- a/Tests/ThirdPartyMailerTests/ThirdPartyMailClientsTests.swift
+++ b/Tests/ThirdPartyMailerTests/ThirdPartyMailClientsTests.swift
@@ -28,167 +28,81 @@ import XCTest
 class ThirdPartyMailClientsTests: XCTestCase {
 
     let clients = ThirdPartyMailClient.clients
-    let application = ApplicationMock()
 
     func clientWithURLScheme(_ URLScheme: String) -> ThirdPartyMailClient? {
         return clients.filter { return $0.URLScheme == URLScheme }.first
     }
 
-    func testClientAvailability() {
-        let client = ThirdPartyMailClient(name: "", URLScheme: "qwerty", URLRoot: nil, URLRecipientKey: nil, URLSubjectKey: nil, URLBodyKey: nil)
-
-        application.canOpenNextURL = true
-
-        let isAvailablePositive = ThirdPartyMailer.isMailClientAvailable(client, with: application)
-        XCTAssertTrue(isAvailablePositive)
-
-        application.canOpenNextURL = false
-
-        let isAvailableNegative = ThirdPartyMailer.isMailClientAvailable(client, with: application)
-        XCTAssertFalse(isAvailableNegative)
-    }
-
     func testSparrow() throws {
         let sparrow = try XCTUnwrap(clientWithURLScheme("sparrow"))
 
-        ThirdPartyMailer.open(sparrow, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "sparrow:")
-
-        ThirdPartyMailer.openCompose(sparrow, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "sparrow:")
-
-        ThirdPartyMailer.openCompose(sparrow, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "sparrow:test@mail.com")
-
-        ThirdPartyMailer.openCompose(sparrow, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "sparrow:test@mail.com?subject=Sub&body=ABC%20def")
+        XCTAssertEqual(sparrow.openURL().absoluteString, "sparrow:")
+        XCTAssertEqual(sparrow.composeURL().absoluteString, "sparrow:")
+        XCTAssertEqual(sparrow.composeURL(to: "test@mail.com").absoluteString, "sparrow:test@mail.com")
+        XCTAssertEqual(sparrow.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "sparrow:test@mail.com?subject=Sub&body=ABC%20def")
     }
 
     func testGmail() throws {
         let gmail = try XCTUnwrap(clientWithURLScheme("googlegmail"))
 
-        ThirdPartyMailer.open(gmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "googlegmail:")
-
-        ThirdPartyMailer.openCompose(gmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "googlegmail:///co")
-
-        ThirdPartyMailer.openCompose(gmail, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "googlegmail:///co?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(gmail, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "googlegmail:///co?to=test@mail.com&subject=Sub&body=ABC%20def")
-
-        ThirdPartyMailer.openCompose(gmail, recipient: "test@mail.com", cc: "testcopy@mail.com", bcc: "blindtestcopy@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "googlegmail:///co?to=test@mail.com&cc=testcopy@mail.com&bcc=blindtestcopy@mail.com")
+        XCTAssertEqual(gmail.openURL().absoluteString, "googlegmail:")
+        XCTAssertEqual(gmail.composeURL().absoluteString, "googlegmail:///co")
+        XCTAssertEqual(gmail.composeURL(to: "test@mail.com").absoluteString, "googlegmail:///co?to=test@mail.com")
+        XCTAssertEqual(gmail.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "googlegmail:///co?to=test@mail.com&subject=Sub&body=ABC%20def")
+        XCTAssertEqual(gmail.composeURL(to: "test@mail.com", cc: "testcopy@mail.com", bcc: "blindtestcopy@mail.com").absoluteString, "googlegmail:///co?to=test@mail.com&cc=testcopy@mail.com&bcc=blindtestcopy@mail.com")
     }
 
     func testDispatch() throws {
         let dispatch = try XCTUnwrap(clientWithURLScheme("x-dispatch"))
 
-        ThirdPartyMailer.open(dispatch, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "x-dispatch:")
-
-        ThirdPartyMailer.openCompose(dispatch, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "x-dispatch:///compose")
-
-        ThirdPartyMailer.openCompose(dispatch, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "x-dispatch:///compose?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(dispatch, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "x-dispatch:///compose?to=test@mail.com&subject=Sub&body=ABC%20def")
+        XCTAssertEqual(dispatch.openURL().absoluteString, "x-dispatch:")
+        XCTAssertEqual(dispatch.composeURL().absoluteString, "x-dispatch:///compose")
+        XCTAssertEqual(dispatch.composeURL(to: "test@mail.com").absoluteString, "x-dispatch:///compose?to=test@mail.com")
+        XCTAssertEqual(dispatch.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "x-dispatch:///compose?to=test@mail.com&subject=Sub&body=ABC%20def")
     }
 
     func testSpark() throws {
         let spark = try XCTUnwrap(clientWithURLScheme("readdle-spark"))
 
-        ThirdPartyMailer.open(spark, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "readdle-spark:")
-
-        ThirdPartyMailer.openCompose(spark, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "readdle-spark://compose")
-
-        ThirdPartyMailer.openCompose(spark, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "readdle-spark://compose?recipient=test@mail.com")
-
-        ThirdPartyMailer.openCompose(spark, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "readdle-spark://compose?recipient=test@mail.com&subject=Sub&body=ABC%20def")
+        XCTAssertEqual(spark.openURL().absoluteString, "readdle-spark:")
+        XCTAssertEqual(spark.composeURL().absoluteString, "readdle-spark://compose")
+        XCTAssertEqual(spark.composeURL(to: "test@mail.com").absoluteString, "readdle-spark://compose?recipient=test@mail.com")
+        XCTAssertEqual(spark.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "readdle-spark://compose?recipient=test@mail.com&subject=Sub&body=ABC%20def")
     }
 
     func testAirmail() throws {
         let airmail = try XCTUnwrap(clientWithURLScheme("airmail"))
 
-        ThirdPartyMailer.open(airmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "airmail:")
-
-        ThirdPartyMailer.openCompose(airmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "airmail://compose")
-
-        ThirdPartyMailer.openCompose(airmail, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "airmail://compose?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(airmail, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "airmail://compose?to=test@mail.com&subject=Sub&plainBody=ABC%20def")
+        XCTAssertEqual(airmail.openURL().absoluteString, "airmail:")
+        XCTAssertEqual(airmail.composeURL().absoluteString, "airmail://compose")
+        XCTAssertEqual(airmail.composeURL(to: "test@mail.com").absoluteString, "airmail://compose?to=test@mail.com")
+        XCTAssertEqual(airmail.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "airmail://compose?to=test@mail.com&subject=Sub&plainBody=ABC%20def")
     }
 
     func testOutlook() throws {
         let outlook = try XCTUnwrap(clientWithURLScheme("ms-outlook"))
 
-        ThirdPartyMailer.open(outlook, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ms-outlook:")
-
-        ThirdPartyMailer.openCompose(outlook, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ms-outlook://compose")
-
-        ThirdPartyMailer.openCompose(outlook, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ms-outlook://compose?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(outlook, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ms-outlook://compose?to=test@mail.com&subject=Sub&body=ABC%20def")
+        XCTAssertEqual(outlook.openURL().absoluteString, "ms-outlook:")
+        XCTAssertEqual(outlook.composeURL().absoluteString, "ms-outlook://compose")
+        XCTAssertEqual(outlook.composeURL(to: "test@mail.com").absoluteString, "ms-outlook://compose?to=test@mail.com")
+        XCTAssertEqual(outlook.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "ms-outlook://compose?to=test@mail.com&subject=Sub&body=ABC%20def")
     }
 
     func testYahooMail() throws {
         let yahoo = try XCTUnwrap(clientWithURLScheme("ymail"))
 
-        ThirdPartyMailer.open(yahoo, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ymail:")
-
-        ThirdPartyMailer.openCompose(yahoo, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ymail://mail/compose")
-
-        ThirdPartyMailer.openCompose(yahoo, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ymail://mail/compose?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(yahoo, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "ymail://mail/compose?to=test@mail.com&subject=Sub&body=ABC%20def")
+        XCTAssertEqual(yahoo.openURL().absoluteString, "ymail:")
+        XCTAssertEqual(yahoo.composeURL().absoluteString, "ymail://mail/compose")
+        XCTAssertEqual(yahoo.composeURL(to: "test@mail.com").absoluteString, "ymail://mail/compose?to=test@mail.com")
+        XCTAssertEqual(yahoo.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "ymail://mail/compose?to=test@mail.com&subject=Sub&body=ABC%20def")
     }
 
     func testFastmail() throws {
         let fastmail = try XCTUnwrap(clientWithURLScheme("fastmail"))
 
-        ThirdPartyMailer.open(fastmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "fastmail:")
-
-        ThirdPartyMailer.openCompose(fastmail, with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "fastmail://mail/compose")
-
-        ThirdPartyMailer.openCompose(fastmail, recipient: "test@mail.com", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "fastmail://mail/compose?to=test@mail.com")
-
-        ThirdPartyMailer.openCompose(fastmail, recipient: "test@mail.com", subject: "Sub", body: "ABC def", with: application)
-        XCTAssertEqual(application.lastOpenedURL?.absoluteString, "fastmail://mail/compose?to=test@mail.com&subject=Sub&body=ABC%20def")
-    }
-}
-
-class ApplicationMock: UIApplicationOpenURLProtocol {
-    var canOpenNextURL = false
-    var lastOpenedURL: URL?
-
-    func canOpenURL(_ url: URL) -> Bool {
-        return canOpenNextURL
-    }
-
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey : Any], completionHandler completion: ((Bool) -> Void)?) {
-        lastOpenedURL = url
+        XCTAssertEqual(fastmail.openURL().absoluteString, "fastmail:")
+        XCTAssertEqual(fastmail.composeURL().absoluteString, "fastmail://mail/compose")
+        XCTAssertEqual(fastmail.composeURL(to: "test@mail.com").absoluteString, "fastmail://mail/compose?to=test@mail.com")
+        XCTAssertEqual(fastmail.composeURL(to: "test@mail.com", subject: "Sub", body: "ABC def").absoluteString, "fastmail://mail/compose?to=test@mail.com&subject=Sub&body=ABC%20def")
     }
 }


### PR DESCRIPTION
As discussed with #26, the current implementation of having a `UIApplicationOpenURLProtocol` and passing `UIApplication` parameters no longer compiles with Xcode 13 and SPM. This pull request solves this issue by removing the application parameters, and only use `UIApplication.shared`. This shouldn’t affect how applications use this library, and only changes how the library can be tested, which seems like a reasonable tradeoff.